### PR TITLE
Addressing feedback from July 4th meeting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1169,6 +1169,21 @@
         "@fortawesome/fontawesome-common-types": "^0.2.28"
       }
     },
+    "@fortawesome/free-solid-svg-icons": {
+      "version": "5.13.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.13.1.tgz",
+      "integrity": "sha512-LQH/0L1p4+rqtoSHa9qFYR84hpuRZKqaQ41cfBQx8b68p21zoWSekTAeA54I/2x9VlCHDLFlG74Nmdg4iTPQOg==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.29"
+      },
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": {
+          "version": "0.2.29",
+          "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.29.tgz",
+          "integrity": "sha512-cY+QfDTbZ7XVxzx7jxbC98Oxr/zc7R2QpTLqTxqlfyXDrAJjzi/xUIqAUsygELB62JIrbsWxtSRhayKFkGI7MA=="
+        }
+      }
+    },
     "@fortawesome/react-fontawesome": {
       "version": "0.1.10",
       "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.10.tgz",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.28",
     "@fortawesome/free-brands-svg-icons": "^5.13.0",
+    "@fortawesome/free-solid-svg-icons": "^5.13.1",
     "@fortawesome/react-fontawesome": "^0.1.10",
     "@material-ui/core": "^4.9.14",
     "@material-ui/icons": "^4.9.1",

--- a/src/Components/Dashboard/Home.js
+++ b/src/Components/Dashboard/Home.js
@@ -7,8 +7,8 @@ import Grid from "@material-ui/core/Grid";
 
 const useStyles = makeStyles(() => ({
   home_page: { 
-    paddingLeft: '5%',
-    paddingRight: '5%',
+    paddingLeft: '15%',
+    paddingRight: '10%',
     justifyContent: 'center',
     alignItems: 'center',
     height: '100%',

--- a/src/Components/Dashboard/UserProfile.js
+++ b/src/Components/Dashboard/UserProfile.js
@@ -2,6 +2,8 @@ import React, {Component} from 'react';
 import {makeStyles} from "@material-ui/core/styles";
 import pic0 from "../Images/faceShot/pic0.png";
 import { Button } from '@material-ui/core';
+import { faLocationArrow, faBuilding } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -187,8 +189,8 @@ class Landing extends Component{
           <span>
             <p className={classes.name}>Ali Khan</p>
             <p className={classes.occupation}>Director of Marketing and Communication</p>
-            <p className={classes.city}>Toronto, ON</p>
-            <p className={classes.company}><b>IBM</b></p>
+            <p className={classes.city}><FontAwesomeIcon icon={faLocationArrow} style={{width: '14px', height: '14px', margin: '2px', marginRight: '10px'}}/>Toronto, ON</p>
+            <p className={classes.company}><FontAwesomeIcon icon={faBuilding} style={{width: '14px', height: '14px', margin: '2px', marginRight: '10px'}}/><b>IBM</b></p>
             <p className={classes.numCoffeChat}>32 Coffee Chats</p>
             <p className={classes.numCoffeChat}>45 Jobs Applied To</p>
             <div className={classes.circle}>

--- a/src/Components/Dashboard/UserProfile.js
+++ b/src/Components/Dashboard/UserProfile.js
@@ -2,7 +2,7 @@ import React, {Component} from 'react';
 import {makeStyles} from "@material-ui/core/styles";
 import pic0 from "../Images/faceShot/pic0.png";
 import { Button } from '@material-ui/core';
-import { faLocationArrow, faBuilding } from '@fortawesome/free-solid-svg-icons';
+import { faMapMarker, faBuilding } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 const useStyles = makeStyles(theme => ({
@@ -189,7 +189,7 @@ class Landing extends Component{
           <span>
             <p className={classes.name}>Ali Khan</p>
             <p className={classes.occupation}>Director of Marketing and Communication</p>
-            <p className={classes.city}><FontAwesomeIcon icon={faLocationArrow} style={{width: '14px', height: '14px', margin: '2px', marginRight: '10px'}}/>Toronto, ON</p>
+            <p className={classes.city}><FontAwesomeIcon icon={faMapMarker} style={{width: '14px', height: '14px', margin: '2px', marginRight: '10px'}}/>Toronto, ON</p>
             <p className={classes.company}><FontAwesomeIcon icon={faBuilding} style={{width: '14px', height: '14px', margin: '2px', marginRight: '10px'}}/><b>IBM</b></p>
             <p className={classes.numCoffeChat}>32 Coffee Chats</p>
             <p className={classes.numCoffeChat}>45 Jobs Applied To</p>

--- a/src/Components/LandingPage/Membership.js
+++ b/src/Components/LandingPage/Membership.js
@@ -271,6 +271,12 @@ class Membership extends Component {
                     <td className={classes.table_element_premium}>10 credits</td>
                     <td className={classes.table_element_plat}>10 credits</td>
                   </tr>
+                  <tr>
+                    <th style={{borderTop: '4px solid #dddddd'}} className={classes.table_element}>Membership Price</th>
+                    <th style={{borderTop: '4px solid #dddddd'}} className={classes.table_element_free}>Free</th>
+                    <th style={{borderTop: '4px solid #dddddd'}} className={classes.table_element_premium}>$49</th>
+                    <th style={{borderTop: '4px solid #dddddd'}} className={classes.table_element_plat}>$75</th>
+                  </tr>
                 </tbody>
               </table>
             </DialogContentText>

--- a/src/Components/LandingPage/Membership.js
+++ b/src/Components/LandingPage/Membership.js
@@ -135,7 +135,7 @@ class Membership extends Component {
         >
           <DialogTitle id="scroll-dialog-title">
             <div>
-              <h2 style={{margin: '0px', marginTop: '10px'}}>Membership Breakdown</h2>
+              <h2 style={{margin: '0px', marginTop: '10px', color: '#B5A165'}}>Membership Options</h2>
             </div>
           </DialogTitle>
           <DialogContent>
@@ -191,6 +191,12 @@ class Membership extends Component {
                     <td className={classes.table_element}>Yes</td>
                   </tr>
                   <tr>
+                    <td className={classes.table_element}>Ability to Post Jobs</td>
+                    <td className={classes.table_element}>No</td>
+                    <td className={classes.table_element}>Yes</td>
+                    <td className={classes.table_element}>Yes</td>
+                  </tr>
+                  <tr>
                     <td className={classes.table_element}>Access to Resume Bank</td>
                     <td className={classes.table_element}>N/A</td>
                     <td className={classes.table_element}>N/A</td>
@@ -230,7 +236,7 @@ class Membership extends Component {
               type="submit"
               variant="contained"
               color="primary"
-              style={{margin: 'auto'}}
+              style={{margin: 'auto', backgroundColor: '#B5A165'}}
             >
               <b>Close</b>
             </Button>

--- a/src/Components/LandingPage/Membership.js
+++ b/src/Components/LandingPage/Membership.js
@@ -169,9 +169,9 @@ class Membership extends Component {
                 <thead>
                   <tr>
                     <th className={classes.table_element}>Feature</th>
-                    <th className={classes.table_element_free}>Free</th>
-                    <th className={classes.table_element_premium}>Premium</th>
-                    <th className={classes.table_element_plat}>Platinum</th>
+                    <th className={classes.table_element_free}>Aspiring Professional - Free</th>
+                    <th className={classes.table_element_premium}>Aspiring Professional - Premium</th>
+                    <th className={classes.table_element_plat}>Senior Executive - Platinum</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -212,22 +212,22 @@ class Membership extends Component {
                     <td className={classes.table_element_plat}>Yes</td>
                   </tr>
                   <tr>
-                    <td className={classes.table_element}>Request 1-on-1 Coffee Chats wtih Senior Executives</td>
+                    <td className={classes.table_element}>1-on-1 Coffee Chats with Senior Executives</td>
                     <td className={classes.table_element_free}>Pay per use</td>
-                    <td className={classes.table_element_premium}>Yes</td>
-                    <td className={classes.table_element_plat}>-</td>
+                    <td className={classes.table_element_premium}>Yes, can request</td>
+                    <td className={classes.table_element_plat}>Yes, leading</td>
                   </tr>
                   <tr>
-                    <td className={classes.table_element}>Request 4-on-1 Coffee Chats wtih Senior Executives</td>
+                    <td className={classes.table_element}>4-on-1 Coffee Chats with Senior Executives</td>
                     <td className={classes.table_element_free}>Pay per use</td>
-                    <td className={classes.table_element_premium}>Yes</td>
-                    <td className={classes.table_element_plat}>-</td>
+                    <td className={classes.table_element_premium}>Yes, can request</td>
+                    <td className={classes.table_element_plat}>Yes, leading</td>
                   </tr>
                   <tr>
-                    <td className={classes.table_element}>Access to Mock Interviews</td>
+                    <td className={classes.table_element}>Mock Interviews with Senior Executives</td>
                     <td className={classes.table_element_free}>Pay per use</td>
-                    <td className={classes.table_element_premium}>Yes</td>
-                    <td className={classes.table_element_plat}>-</td>
+                    <td className={classes.table_element_premium}>Yes, can request</td>
+                    <td className={classes.table_element_plat}>Yes, leading</td>
                   </tr>
                   <tr>
                     <td className={classes.table_element}>Ability to Apply to Board Roles</td>
@@ -243,21 +243,21 @@ class Membership extends Component {
                   </tr>
                   <tr>
                     <td className={classes.table_element}>Access to Resume Bank</td>
-                    <td className={classes.table_element_free}>-</td>
-                    <td className={classes.table_element_premium}>-</td>
+                    <td className={classes.table_element_free}>No</td>
+                    <td className={classes.table_element_premium}>No</td>
                     <td className={classes.table_element_plat}>Yes</td>
                   </tr>
                   <tr>
                     <td className={classes.table_element}>Option to Sponsor an Aspiring Professional who is Financially Constrained</td>
-                    <td className={classes.table_element_free}>-</td>
+                    <td className={classes.table_element_free}>No</td>
                     <td className={classes.table_element_premium}>Yes ($49 or more)</td>
                     <td className={classes.table_element_plat}>Yes ($49 or more)</td>
                   </tr>
                   <tr>
                     <td className={classes.table_element}>Starting Credits Received</td>
-                    <td className={classes.table_element_free}>0</td>
-                    <td className={classes.table_element_premium}>30</td>
-                    <td className={classes.table_element_plat}>30</td>
+                    <td className={classes.table_element_free}>0 credits</td>
+                    <td className={classes.table_element_premium}>30 credits</td>
+                    <td className={classes.table_element_plat}>30 credits</td>
                   </tr>
                   <tr>
                     <td className={classes.table_element}>Cost to Purchase 5 Additional Credits</td>

--- a/src/Components/LandingPage/Membership.js
+++ b/src/Components/LandingPage/Membership.js
@@ -52,6 +52,27 @@ const useStyles = makeStyles(() => ({
     border: '1px solid #dddddd',
     textAlign: 'left',
     padding: '8px'
+  },
+  table_element_free: {
+    border: '1px solid #dddddd',
+    textAlign: 'left',
+    padding: '8px',
+    backgroundColor: '#daa067',
+    color: 'white'
+  },
+  table_element_premium: {
+    border: '1px solid #dddddd',
+    textAlign: 'left',
+    padding: '8px',
+    backgroundColor: '#A9A9A9',
+    color: 'white'
+  },
+  table_element_plat: {
+    border: '1px solid #dddddd',
+    textAlign: 'left',
+    padding: '8px',
+    backgroundColor: '#B5A165',
+    color: 'white'
   }
 }));
 
@@ -148,83 +169,107 @@ class Membership extends Component {
                 <thead>
                   <tr>
                     <th className={classes.table_element}>Feature</th>
-                    <th className={classes.table_element}>Free</th>
-                    <th className={classes.table_element}>Premium</th>
-                    <th className={classes.table_element}>Platinum</th>
+                    <th className={classes.table_element_free}>Free</th>
+                    <th className={classes.table_element_premium}>Premium</th>
+                    <th className={classes.table_element_plat}>Platinum</th>
                   </tr>
                 </thead>
                 <tbody>
                   <tr>
-                    <td className={classes.table_element}>See Profiles of Senior Executives Committed to MAX Aspire</td>
-                    <td className={classes.table_element}>Yes</td>
-                    <td className={classes.table_element}>Yes</td>
-                    <td className={classes.table_element}>Yes</td>
+                    <td className={classes.table_element}>Ability to View Job Postings</td>
+                    <td className={classes.table_element_free}>Yes</td>
+                    <td className={classes.table_element_premium}>Yes</td>
+                    <td className={classes.table_element_plat}>Yes</td>
                   </tr>
                   <tr>
-                    <td className={classes.table_element}>Request 1-on-1 Coffee Chats wtih Senior Executives</td>
-                    <td className={classes.table_element}>Pay per use</td>
-                    <td className={classes.table_element}>Yes</td>
-                    <td className={classes.table_element}>N/A</td>
+                    <td className={classes.table_element}>Ability to Apply for Jobs Posted</td>
+                    <td className={classes.table_element_free}>No</td>
+                    <td className={classes.table_element_premium}>Yes</td>
+                    <td className={classes.table_element_plat}>Yes</td>
                   </tr>
                   <tr>
-                    <td className={classes.table_element}>Request 4-on-1 Coffee Chats wtih Senior Executives</td>
-                    <td className={classes.table_element}>Pay per use</td>
-                    <td className={classes.table_element}>Yes</td>
-                    <td className={classes.table_element}>N/A</td>
+                    <td className={classes.table_element}>Ability to Contact Person who Posted the Job</td>
+                    <td className={classes.table_element_free}>No</td>
+                    <td className={classes.table_element_premium}>Yes</td>
+                    <td className={classes.table_element_plat}>Yes</td>
                   </tr>
                   <tr>
-                    <td className={classes.table_element}>Access to Mock Interviews</td>
-                    <td className={classes.table_element}>Pay per use</td>
-                    <td className={classes.table_element}>Yes</td>
-                    <td className={classes.table_element}>N/A</td>
-                  </tr>
-                  <tr>
-                    <td className={classes.table_element}>Ability to Apply to Board Roles</td>
-                    <td className={classes.table_element}>No</td>
-                    <td className={classes.table_element}>Yes</td>
-                    <td className={classes.table_element}>Yes</td>
-                  </tr>
-                  <tr>
-                    <td className={classes.table_element}>Ability to Contact Individual who Posted Board Role</td>
-                    <td className={classes.table_element}>No</td>
-                    <td className={classes.table_element}>Yes</td>
-                    <td className={classes.table_element}>Yes</td>
+                    <td className={classes.table_element}>Post Resume/CV on Jobs Bank (accessible by Senior Executives)</td>
+                    <td className={classes.table_element_free}>Yes</td>
+                    <td className={classes.table_element_premium}>Yes</td>
+                    <td className={classes.table_element_plat}>Yes</td>
                   </tr>
                   <tr>
                     <td className={classes.table_element}>Ability to Post Jobs</td>
-                    <td className={classes.table_element}>No</td>
-                    <td className={classes.table_element}>Yes</td>
-                    <td className={classes.table_element}>Yes</td>
+                    <td className={classes.table_element_free}>No</td>
+                    <td className={classes.table_element_premium}>Yes</td>
+                    <td className={classes.table_element_plat}>Yes</td>
+                  </tr>
+                  <tr>
+                    <td className={classes.table_element}>See Profiles of Senior Executives Committed to MAX Aspire</td>
+                    <td className={classes.table_element_free}>Yes</td>
+                    <td className={classes.table_element_premium}>Yes</td>
+                    <td className={classes.table_element_plat}>Yes</td>
+                  </tr>
+                  <tr>
+                    <td className={classes.table_element}>Request 1-on-1 Coffee Chats wtih Senior Executives</td>
+                    <td className={classes.table_element_free}>Pay per use</td>
+                    <td className={classes.table_element_premium}>Yes</td>
+                    <td className={classes.table_element_plat}>N/A</td>
+                  </tr>
+                  <tr>
+                    <td className={classes.table_element}>Request 4-on-1 Coffee Chats wtih Senior Executives</td>
+                    <td className={classes.table_element_free}>Pay per use</td>
+                    <td className={classes.table_element_premium}>Yes</td>
+                    <td className={classes.table_element_plat}>N/A</td>
+                  </tr>
+                  <tr>
+                    <td className={classes.table_element}>Access to Mock Interviews</td>
+                    <td className={classes.table_element_free}>Pay per use</td>
+                    <td className={classes.table_element_premium}>Yes</td>
+                    <td className={classes.table_element_plat}>N/A</td>
+                  </tr>
+                  <tr>
+                    <td className={classes.table_element}>Ability to Apply to Board Roles</td>
+                    <td className={classes.table_element_free}>No</td>
+                    <td className={classes.table_element_premium}>Yes</td>
+                    <td className={classes.table_element_plat}>Yes</td>
+                  </tr>
+                  <tr>
+                    <td className={classes.table_element}>Ability to Contact Individual who Posted Board Role</td>
+                    <td className={classes.table_element_free}>No</td>
+                    <td className={classes.table_element_premium}>Yes</td>
+                    <td className={classes.table_element_plat}>Yes</td>
                   </tr>
                   <tr>
                     <td className={classes.table_element}>Access to Resume Bank</td>
-                    <td className={classes.table_element}>N/A</td>
-                    <td className={classes.table_element}>N/A</td>
-                    <td className={classes.table_element}>Yes</td>
+                    <td className={classes.table_element_free}>N/A</td>
+                    <td className={classes.table_element_premium}>N/A</td>
+                    <td className={classes.table_element_plat}>Yes</td>
                   </tr>
                   <tr>
                     <td className={classes.table_element}>Option to Sponsor an Aspiring Professional who is Financially Constrained</td>
-                    <td className={classes.table_element}>N/A</td>
-                    <td className={classes.table_element}>Yes ($49 or $98)</td>
-                    <td className={classes.table_element}>Yes ($49 or $98)</td>
+                    <td className={classes.table_element_free}>N/A</td>
+                    <td className={classes.table_element_premium}>Yes ($49 or $98)</td>
+                    <td className={classes.table_element_plat}>Yes ($49 or $98)</td>
                   </tr>
                   <tr>
                     <td className={classes.table_element}>Starting Credits Received</td>
-                    <td className={classes.table_element}>0</td>
-                    <td className={classes.table_element}>30</td>
-                    <td className={classes.table_element}>30</td>
+                    <td className={classes.table_element_free}>0</td>
+                    <td className={classes.table_element_premium}>30</td>
+                    <td className={classes.table_element_plat}>30</td>
                   </tr>
                   <tr>
                     <td className={classes.table_element}>Cost to Purchase 5 Additional Credits</td>
-                    <td className={classes.table_element}>$10</td>
-                    <td className={classes.table_element}>$5</td>
-                    <td className={classes.table_element}>$5</td>
+                    <td className={classes.table_element_free}>$10</td>
+                    <td className={classes.table_element_premium}>$5</td>
+                    <td className={classes.table_element_plat}>$5</td>
                   </tr>
                   <tr>
                     <td className={classes.table_element}>Refer a Friend Signup Bonus</td>
-                    <td className={classes.table_element}>10 credits</td>
-                    <td className={classes.table_element}>10 credits</td>
-                    <td className={classes.table_element}>10 credits</td>
+                    <td className={classes.table_element_free}>10 credits</td>
+                    <td className={classes.table_element_premium}>10 credits</td>
+                    <td className={classes.table_element_plat}>10 credits</td>
                   </tr>
                 </tbody>
               </table>

--- a/src/Components/LandingPage/Membership.js
+++ b/src/Components/LandingPage/Membership.js
@@ -215,19 +215,19 @@ class Membership extends Component {
                     <td className={classes.table_element}>Request 1-on-1 Coffee Chats wtih Senior Executives</td>
                     <td className={classes.table_element_free}>Pay per use</td>
                     <td className={classes.table_element_premium}>Yes</td>
-                    <td className={classes.table_element_plat}>N/A</td>
+                    <td className={classes.table_element_plat}>-</td>
                   </tr>
                   <tr>
                     <td className={classes.table_element}>Request 4-on-1 Coffee Chats wtih Senior Executives</td>
                     <td className={classes.table_element_free}>Pay per use</td>
                     <td className={classes.table_element_premium}>Yes</td>
-                    <td className={classes.table_element_plat}>N/A</td>
+                    <td className={classes.table_element_plat}>-</td>
                   </tr>
                   <tr>
                     <td className={classes.table_element}>Access to Mock Interviews</td>
                     <td className={classes.table_element_free}>Pay per use</td>
                     <td className={classes.table_element_premium}>Yes</td>
-                    <td className={classes.table_element_plat}>N/A</td>
+                    <td className={classes.table_element_plat}>-</td>
                   </tr>
                   <tr>
                     <td className={classes.table_element}>Ability to Apply to Board Roles</td>
@@ -243,15 +243,15 @@ class Membership extends Component {
                   </tr>
                   <tr>
                     <td className={classes.table_element}>Access to Resume Bank</td>
-                    <td className={classes.table_element_free}>N/A</td>
-                    <td className={classes.table_element_premium}>N/A</td>
+                    <td className={classes.table_element_free}>-</td>
+                    <td className={classes.table_element_premium}>-</td>
                     <td className={classes.table_element_plat}>Yes</td>
                   </tr>
                   <tr>
                     <td className={classes.table_element}>Option to Sponsor an Aspiring Professional who is Financially Constrained</td>
-                    <td className={classes.table_element_free}>N/A</td>
-                    <td className={classes.table_element_premium}>Yes ($49 or $98)</td>
-                    <td className={classes.table_element_plat}>Yes ($49 or $98)</td>
+                    <td className={classes.table_element_free}>-</td>
+                    <td className={classes.table_element_premium}>Yes ($49 or more)</td>
+                    <td className={classes.table_element_plat}>Yes ($49 or more)</td>
                   </tr>
                   <tr>
                     <td className={classes.table_element}>Starting Credits Received</td>


### PR DESCRIPTION
No associated issue. Addressing the comments from the meeting today.

In particular:
- padding between dashboard and user profile
- colour of membership popup `close` button
- symbol beside location & company on user profile
- another entry in membership information table, `ability to post job`
- change wording of membership popup title

The membership options table looks like this now:
![image](https://user-images.githubusercontent.com/13268990/86524945-8a957a80-be4e-11ea-8302-7a0ed82639ad.png)