### PR TITLE
Address the following changes

### DIFF
--- a/src/Components/LandingPage/Membership.js
+++ b/src/Components/LandingPage/Membership.js
@@ -1,6 +1,6 @@
 import React, {Component} from "react";
+
 import Grid from "@material-ui/core/Grid";
-import MembershipCard from "./MembershipCard.js"
 import {makeStyles} from "@material-ui/core/styles";
 import Dialog from "@material-ui/core/Dialog";
 import DialogTitle from "@material-ui/core/DialogTitle";
@@ -8,6 +8,10 @@ import DialogContent from "@material-ui/core/DialogContent";
 import DialogContentText from "@material-ui/core/DialogContentText";
 import DialogActions from "@material-ui/core/DialogActions";
 import Button from "@material-ui/core/Button";
+import InfoOutlinedIcon from '@material-ui/icons/InfoOutlined';
+import Tooltip from '@material-ui/core/Tooltip';
+
+import MembershipCard from "./MembershipCard.js"
 
 const useStyles = makeStyles(() => ({
   background: {
@@ -72,7 +76,11 @@ const useStyles = makeStyles(() => ({
     padding: '8px',
     backgroundColor: '#B5A165',
     color: 'white'
-  }
+  },
+  tooltip: {
+    display: 'inline-block',
+    marginLeft: '10px',
+  },
 }));
 
 function withMyHook(Component) {
@@ -137,14 +145,20 @@ class Membership extends Component {
     const classes = this.props.classes;
     return(
       <div className={classes.background}>
-        <h1 className={classes.features_title}>Memberships</h1>
+        <h1 className={classes.features_title}>Memberships
+          <div className={classes.tooltip} onClick={this.openMemberships} >
+            <Tooltip  title="More information about the membership options">
+              <InfoOutlinedIcon size="x2"/>
+            </Tooltip>
+          </div>
+        </h1>
         <Grid
           container
           spacing={8}
           alignItems="center"
           justify="center"
           className={classes.grid}
-          > 
+          >
           <Grid
             container
             item xs={12} sm={9} md={6} lg={4}
@@ -153,7 +167,8 @@ class Membership extends Component {
           >
             <div style={this.state.aspire_free}>
               <MembershipCard
-                  front_text={"Aspiring Professionals Free"}
+                  membership_type_text="Free"
+                  front_text={"Aspiring Professionals"}
                   inner_text="Pricing Plan:"
                   description="With the free membership plan, you will able to view jobs on the platform and you can schedule coffee chats and mock interviews on a pay per use basis"
                   type="aspiring_professional"
@@ -171,7 +186,8 @@ class Membership extends Component {
           >
             <div style={this.state.aspire_premium}>
               <MembershipCard
-                  front_text="Aspiring Professionals Premium"
+                  membership_type_text="Premium"
+                  front_text="Aspiring Professionals"
                   inner_text="Pricing Plan:"
                   description="With the premium membership plan, you can view and apply to jobs, and get 30 credits to schedule coffee chats and mock interviews with senior executives"
                   type="aspiring_professional"
@@ -189,7 +205,8 @@ class Membership extends Component {
           >
             <div style={this.state.aspire_platinum}>
               <MembershipCard
-                  front_text="Senior Professionals Platinum"
+                  membership_type_text="Platinum"
+                  front_text="Senior Professionals"
                   inner_text="Pricing Plan"
                   description="The Platinum plan gives you exclusive access to board positions, the opportunity to mentor aspiring professionals, hire great talent, and connect with fellow senior professionals!"
                   type="senior_professional"
@@ -200,7 +217,6 @@ class Membership extends Component {
             </div>
           </Grid>
         </Grid>
-        <p className={classes.more_info} onClick={this.openMemberships}>more information about the membership options</p>
         <Dialog
           open={this.state.open}
           onClose={this.handleClose}

--- a/src/Components/LandingPage/MembershipCard.js
+++ b/src/Components/LandingPage/MembershipCard.js
@@ -5,7 +5,7 @@ import {makeStyles} from "@material-ui/core/styles";
 import Button from '@material-ui/core/Button';
 
 const useStyles = makeStyles(theme => ({
-  image: { 
+  image: {
     width: '100%',
     height: '300px',
     paddingBottom: '30px',
@@ -15,15 +15,22 @@ const useStyles = makeStyles(theme => ({
     height: '100%',
     backgroundColor: '#F1F1F1'
   },
-  front_text: { 
+  membership_type_text: {
     fontFamily: "Nunito Sans",
     fontWeight: "Bold",
     fontSize: "28px",
+    color: 'black',
+    textAlign: 'center'
+  },
+  front_text: {
+    fontFamily: "Nunito Sans",
+    fontWeight: "Bold",
+    fontSize: "22px",
     paddingBottom: '10px',
     color: 'black',
     textAlign: 'center'
   },
-  small_text: { 
+  small_text: {
     fontFamily: "Montserrat",
     fontSize: "18px",
     fontWeight: '1',
@@ -66,6 +73,7 @@ class MembershipCard extends Component {
       <div>
         <div className={classes.card}>
           <img className={classes.image} src={this.props.type === 'aspiring_professional' ? AspiringProfessional : SeniorExecutive} alt="Membership"/>
+          <h2 className={classes.membership_type_text}>{this.props.membership_type_text}</h2>
           <h2 className={classes.front_text}>{this.props.front_text}</h2>
           <h2 className={classes.small_text}>{this.props.description}</h2>
           <Button className={classes.button} variant="contained" onClick={this.props.buttonFunction}><b>{this.props.buttonText}</b></Button>


### PR DESCRIPTION
- Move the table that gets opened from clicking the div "More
infomration ..." to a tooltip beside the Membership title
- Change the Membership card layout
    - Put the membership type as a separate title
    - Move "Aspiring Professionals" into its own title