### PR TITLE
Connecting Mailchimp to Registration Flow

### DIFF
--- a/src/Components/LandingPage/Footer.js
+++ b/src/Components/LandingPage/Footer.js
@@ -126,16 +126,16 @@ const CustomForm = ({ status, message, onValidated, classes }) => {
         alignItems="center"
         justify="flex-start"
       >
-        {status === "sending" && <div style={{ color: "blue" }}>sending...</div>}
+        {status === "sending" && <div style={{ color: "blue", fontSize: '12px' }}>sending...</div>}
         {status === "error" && (
           <div
-            style={{ color: "red" }}
+            style={{ color: "red", fontSize: '12px' }}
             dangerouslySetInnerHTML={{ __html: message }}
           />
         )}
         {status === "success" && (
           <div
-            style={{ color: "green" }}
+            style={{ color: "green", fontSize: '12px' }}
             dangerouslySetInnerHTML={{ __html: message }}
           />
         )}

--- a/src/Components/Registration/FinalPage.js
+++ b/src/Components/Registration/FinalPage.js
@@ -160,36 +160,6 @@ function withMyHook(Component){
     }
 }
 
-const CustomForm = ({ status, message, onValidated, classes, email }) => {
-    let checked = false
-
-    const submit = () =>
-        email &&
-        email.indexOf("@") > -1 &&
-        onValidated({
-          EMAIL: email
-        });
-
-    return (
-        <Grid item xs={12}>
-            <FormControlLabel
-                control={
-                    <Checkbox
-                        checked={checked}
-                        onChange={submit}
-                        name="checkedD"
-                    />}
-                label={
-                    <Tooltip title={
-                        <p>TODO: tooltip text</p>}>
-                        <b>I would like to signup for MAX Aspire related emails</b>
-                    </Tooltip>
-                }
-            />
-        </Grid>
-    );
-};
-
 class FinalPage extends Component{
     constructor(props) {
         super(props);
@@ -317,18 +287,6 @@ class FinalPage extends Component{
         this.setState({
             confirmationCode: event.target.value
         })
-    };
-
-    handleAspireEmailChoice = (event) => {
-        if (this.state.aspire_email_consent ===  false) {
-            this.setState({
-                aspire_email_consent: true,
-            })
-        } else {
-            this.setState({
-                aspire_email_consent: false,
-            })
-        }
     };
 
     handleStripeClose = (event) => {
@@ -475,34 +433,18 @@ class FinalPage extends Component{
                                     }
                                 />
                             </Grid>
-                            <MailchimpSubscribe
-                                url={this.state.url}
-                                render={({ subscribe, status, message }) => (
-                                    <CustomForm
-                                        status={status}
-                                        message={message}
-                                        onValidated={formData => subscribe(formData)}
-                                        classes={classes}
-                                        email={this.state.email}
-                                    />
-                                )}
-                            />
-                            {/*<Grid item xs={12}>
-                                <FormControlLabel
-                                    control={
-                                        <Checkbox
-                                            checked={this.state.aspire_email_consent}
-                                            onChange={this.handleAspireEmailChoice}
-                                            name="checkedD"
-                                        />}
-                                    label={
-                                        <Tooltip title={
-                                            <p>TODO: tooltip text</p>}>
-                                            <b>I would like to signup for MAX Aspire related emails</b>
-                                        </Tooltip>
-                                    }
+                            <Grid item xs={12}>
+                                <Tooltip title={
+                                    <p>Senior Executive means the chief executive officer,
+                                        chief operating officer, chief financial officer, or
+                                        anyone in charge of a principal business unit or function.
+                                    </p>}>
+                                    <b>If you would like to be added to the MAX Aspire mailing service, please confirm your email!</b>
+                                </Tooltip>
+                                <MailchimpSubscribe
+                                    url={this.state.url}
                                 />
-                            </Grid>*/}
+                            </Grid>
                             <Grid item xs={12}>
                                 <FormControlLabel
                                     control={

--- a/src/Components/Registration/FinalPage.js
+++ b/src/Components/Registration/FinalPage.js
@@ -22,6 +22,8 @@ import Landing from "../LandingPage/Landing";
 import { Auth } from 'aws-amplify';
 import TextField from '@material-ui/core/TextField';
 import { Document, Page, pdfjs } from "react-pdf";
+import MailchimpSubscribe from "react-mailchimp-subscribe";
+
 pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.js`;
 
 const useStyles = makeStyles((theme) => ({
@@ -158,6 +160,36 @@ function withMyHook(Component){
     }
 }
 
+const CustomForm = ({ status, message, onValidated, classes, email }) => {
+    let checked = false
+
+    const submit = () =>
+        email &&
+        email.indexOf("@") > -1 &&
+        onValidated({
+          EMAIL: email
+        });
+
+    return (
+        <Grid item xs={12}>
+            <FormControlLabel
+                control={
+                    <Checkbox
+                        checked={checked}
+                        onChange={submit}
+                        name="checkedD"
+                    />}
+                label={
+                    <Tooltip title={
+                        <p>TODO: tooltip text</p>}>
+                        <b>I would like to signup for MAX Aspire related emails</b>
+                    </Tooltip>
+                }
+            />
+        </Grid>
+    );
+};
+
 class FinalPage extends Component{
     constructor(props) {
         super(props);
@@ -179,7 +211,6 @@ class FinalPage extends Component{
             resumeURL: this.props.prev ? this.props.prev.resumeURL : '',
             profilePicURL: this.props.prev ? this.props.prev.profilePicURL : '',
             senior_executive: this.props.prev ? this.props.prev.senior_executive : false,
-            general_email_consent: this.props.prev ? this.props.prev.general_email_consent : false,
             aspire_email_consent: this.props.prev ? this.props.prev.aspire_email_consent : false,
             aspire_free: true,
             aspire_premium: false,
@@ -191,7 +222,8 @@ class FinalPage extends Component{
             confirmationCode: '',
             openStripe: false,
             tocNumPages: null,
-            privacyNumPages: null
+            privacyNumPages: null,
+            url: process.env.REACT_APP_MAILCHIMP_URL
         }
     }
 
@@ -285,18 +317,6 @@ class FinalPage extends Component{
         this.setState({
             confirmationCode: event.target.value
         })
-    };
-
-    handleGeneralEmailChoice = (event) => {
-        if (this.state.general_email_consent ===  false) {
-            this.setState({
-                general_email_consent: true,
-            })
-        } else {
-            this.setState({
-                general_email_consent: false,
-            })
-        }
     };
 
     handleAspireEmailChoice = (event) => {
@@ -401,14 +421,14 @@ class FinalPage extends Component{
                                     />
                                 </Grid>
                                 <Button
-                                        disabled={!this.state.checked}
-                                        type="submit"
-                                        variant="contained"
-                                        color="primary"
-                                        className={classes.submit}
-                                        onClick={this.handleSubmit}
-                                    >
-                                        <b>Submit</b>
+                                    disabled={!this.state.checked}
+                                    type="submit"
+                                    variant="contained"
+                                    color="primary"
+                                    className={classes.submit}
+                                    onClick={this.handleSubmit}
+                                >
+                                    <b>Submit</b>
                                 </Button>
                             </div>
                         </Grid>
@@ -455,23 +475,19 @@ class FinalPage extends Component{
                                     }
                                 />
                             </Grid>
-                            <Grid item xs={12}>
-                                <FormControlLabel
-                                    control={
-                                        <Checkbox
-                                            checked={this.state.general_email_consent}
-                                            onChange={this.handleGeneralEmailChoice}
-                                            name="checkedD"
-                                        />}
-                                    label={
-                                        <Tooltip title={
-                                            <p>TODO: tooltip text</p>}>
-                                            <b>I would like to signup for general MAX related emails</b>
-                                        </Tooltip>
-                                    }
-                                />
-                            </Grid>
-                            <Grid item xs={12}>
+                            <MailchimpSubscribe
+                                url={this.state.url}
+                                render={({ subscribe, status, message }) => (
+                                    <CustomForm
+                                        status={status}
+                                        message={message}
+                                        onValidated={formData => subscribe(formData)}
+                                        classes={classes}
+                                        email={this.state.email}
+                                    />
+                                )}
+                            />
+                            {/*<Grid item xs={12}>
                                 <FormControlLabel
                                     control={
                                         <Checkbox
@@ -486,7 +502,7 @@ class FinalPage extends Component{
                                         </Tooltip>
                                     }
                                 />
-                            </Grid>
+                            </Grid>*/}
                             <Grid item xs={12}>
                                 <FormControlLabel
                                     control={

--- a/src/Components/Registration/FinalPage.js
+++ b/src/Components/Registration/FinalPage.js
@@ -435,10 +435,7 @@ class FinalPage extends Component{
                             </Grid>
                             <Grid item xs={12}>
                                 <Tooltip title={
-                                    <p>Senior Executive means the chief executive officer,
-                                        chief operating officer, chief financial officer, or
-                                        anyone in charge of a principal business unit or function.
-                                    </p>}>
+                                    <p>MAX Aspire will only reach out to you for important updates including (but not limited to) subscription expiration, new features, security concerns, and other important updates. We may also reach out to inform you about big events MAX is hosting and other major updates in the Muslim Community.</p>}>
                                     <b>If you would like to be added to the MAX Aspire mailing service, please confirm your email!</b>
                                 </Tooltip>
                                 <MailchimpSubscribe


### PR DESCRIPTION
close #137 

Also fixed up some formatting issues on landing page.

Visually, the registration page component looks like:
![image](https://user-images.githubusercontent.com/13268990/95658196-a01dde80-0ae6-11eb-9cbd-6845d3e132fe.png)

With hover text (tooltip text):
![image](https://user-images.githubusercontent.com/13268990/95658204-a9a74680-0ae6-11eb-87c5-f1e35ae5528c.png)

After filling in your email and clicking submit, a helpful notification is provided (already subscribed, error, or success):
![image](https://user-images.githubusercontent.com/13268990/95658230-cb083280-0ae6-11eb-89c6-d6bb790d5b3e.png)

Which can be changed upon updated verbiage from the exec team.