### PR TITLE
adding logic to redirect to admin dashboard on signin if user is admin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4831,6 +4831,15 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -7788,6 +7797,12 @@
         "tslib": "^1.9.0"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
     "filesize": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.0.1.tgz",
@@ -9440,7 +9455,11 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         }
       }
     },
@@ -10694,6 +10713,12 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -15830,7 +15855,11 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/src/Components/Authentication/SignIn.js
+++ b/src/Components/Authentication/SignIn.js
@@ -396,7 +396,7 @@ class SignIn extends Component {
                         <img src={MaxBrand} alt="MAX_brand" className={classes.avatar} />
                         <Typography component="h1" variant="h5">
                             Sign in
-            </Typography>
+                        </Typography>
                         <TextField
                             variant="outlined"
                             margin="normal"
@@ -435,7 +435,7 @@ class SignIn extends Component {
                             onClick={this.handleClick}
                         >
                             Sign In
-            </Button>
+                        </Button>
                         <br />
                         <Grid container>
                             <Grid item xs={12}>

--- a/src/Components/Authentication/SignIn.js
+++ b/src/Components/Authentication/SignIn.js
@@ -317,9 +317,9 @@ class SignIn extends Component {
                             <img src={MaxBrand} alt="MAX_brand" className={classes.avatar} />
                             <Typography component="h1" variant="body1">
                                 <b style={{ color: "Red" }}>{this.state.username}</b> has not
-                been verifed. <br />
-                Please enter the verification code below:
-              </Typography>
+                                been verifed. <br />
+                                Please enter the verification code below:
+                            </Typography>
                             <TextField
                                 variant="outlined"
                                 margin="normal"
@@ -343,7 +343,7 @@ class SignIn extends Component {
                                 onClick={this.handleVerify}
                             >
                                 Verify User
-              </Button>
+                            </Button>
                             <br />
                             <Grid container>
                                 <Grid item xs={12}>

--- a/src/Components/Authentication/SignIn.js
+++ b/src/Components/Authentication/SignIn.js
@@ -15,94 +15,94 @@ import Registration from "../Registration/Registration";
 import Landing from "../LandingPage/Landing";
 import signInImage from "../Images/aboutMax.jpg";
 import Dashboard from "../Dashboard/Dashboard";
-import { Auth } from 'aws-amplify';
-import CircularProgress from '@material-ui/core/CircularProgress';
+import { Auth } from "aws-amplify";
+import CircularProgress from "@material-ui/core/CircularProgress";
 import AdminDashboard from "../Admin/Dashboard";
 import jwtDecode from "jwt-decode";
 
 const useStyles = makeStyles((theme) => ({
-  root: {
-    height: "100vh",
-  },
-  appBarSpacer: theme.mixins.toolbar,
-  // appBar background restrictions for transparency
-  appBar: {
-    backgroundColor: "rgba(0,0,0, 0.9)",
-    boxShadow: "none",
-  },
-  // this css element is for the div containing the image
-  // this is used so that we can align the image to the right
-  imageLogo: {
-    display: "flex",
-    justifyContent: "start",
-  },
-  // this css element describes the size of the image
-  img: {
-    float: "left",
-    align: "left",
-    "@media (max-width: 480px)": { width: "125px" },
-    width: "175px",
-    "&:hover": {
-      cursor: "pointer",
-      filter: "sepia(60%)",
+    root: {
+        height: "100vh",
     },
-  },
-  image: {
-    backgroundImage: `url(${signInImage})`, //'url(https://i.picsum.photos/id/1003/1181/1772.jpg)',
-    backgroundRepeat: "no-repeat",
-    backgroundColor:
-      theme.palette.type === "light"
-        ? theme.palette.grey[50]
-        : theme.palette.grey[900],
-    backgroundSize: "cover",
-    backgroundPosition: "center",
-  },
-  paper: {
-    margin: theme.spacing(8, 4),
-    display: "flex",
-    flexDirection: "column",
-    alignItems: "center",
-  },
-  avatar: {
-    marginTop: "10vh",
-    width: "100px",
-    height: "100px",
-    padding: "1vw",
-  },
-  form: {
-    width: "100%", // Fix IE 11 issue.
-    marginTop: theme.spacing(1),
-  },
-  submit: {
-    margin: theme.spacing(3, 0, 2),
-  },
-  button: {
-    backgroundColor: "#6EA0B5",
-    marginTop: "2%",
-    height: 50,
-    width: "50%",
-    borderRadius: 50,
-    color: "white",
-    "&:hover": {
-      backgroundColor: "#F1F1F1",
-      color: "#484848",
+    appBarSpacer: theme.mixins.toolbar,
+    // appBar background restrictions for transparency
+    appBar: {
+        backgroundColor: "rgba(0,0,0, 0.9)",
+        boxShadow: "none",
     },
-  }, 
-  circleProgress: {
-    marginTop: "2%"
-  },
-  toolbar: {
-    display: 'flex',
-    justifyContent: 'flex-start',
-    height: '10vh'
-  }
+    // this css element is for the div containing the image
+    // this is used so that we can align the image to the right
+    imageLogo: {
+        display: "flex",
+        justifyContent: "start",
+    },
+    // this css element describes the size of the image
+    img: {
+        float: "left",
+        align: "left",
+        "@media (max-width: 480px)": { width: "125px" },
+        width: "175px",
+        "&:hover": {
+            cursor: "pointer",
+            filter: "sepia(60%)",
+        },
+    },
+    image: {
+        backgroundImage: `url(${signInImage})`, //'url(https://i.picsum.photos/id/1003/1181/1772.jpg)',
+        backgroundRepeat: "no-repeat",
+        backgroundColor:
+            theme.palette.type === "light"
+                ? theme.palette.grey[50]
+                : theme.palette.grey[900],
+        backgroundSize: "cover",
+        backgroundPosition: "center",
+    },
+    paper: {
+        margin: theme.spacing(8, 4),
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+    },
+    avatar: {
+        marginTop: "10vh",
+        width: "100px",
+        height: "100px",
+        padding: "1vw",
+    },
+    form: {
+        width: "100%", // Fix IE 11 issue.
+        marginTop: theme.spacing(1),
+    },
+    submit: {
+        margin: theme.spacing(3, 0, 2),
+    },
+    button: {
+        backgroundColor: "#6EA0B5",
+        marginTop: "2%",
+        height: 50,
+        width: "50%",
+        borderRadius: 50,
+        color: "white",
+        "&:hover": {
+            backgroundColor: "#F1F1F1",
+            color: "#484848",
+        },
+    },
+    circleProgress: {
+        marginTop: "2%",
+    },
+    toolbar: {
+        display: "flex",
+        justifyContent: "flex-start",
+        height: "10vh",
+    },
 }));
 
 function withMyHook(Component) {
-  return function WrappedComponent(props) {
-    const classes = useStyles();
-    return <Component {...props} classes={classes} />;
-  };
+    return function WrappedComponent(props) {
+        const classes = useStyles();
+        return <Component {...props} classes={classes} />;
+    };
 }
 
 class SignIn extends Component {
@@ -111,13 +111,15 @@ class SignIn extends Component {
         this.state = {
             username: "",
             password: "",
-            signedIn: false, 
-            barDisplay: 'None', 
-            buttonDisplay: '', 
-            errorMessage: '', 
-            verified: true, 
-            verfiedCode: '', 
-            codeMessage: 'Resend the code?'
+            isAdmin: false,
+            isSeniorExec: false,
+            signedIn: false,
+            barDisplay: "None",
+            buttonDisplay: "",
+            errorMessage: "",
+            verified: true,
+            verfiedCode: "",
+            codeMessage: "Resend the code?",
         };
     }
 
@@ -132,107 +134,112 @@ class SignIn extends Component {
             currentScreen: <Registration appContext={this.props.appContext} />,
         });
     };
-    
+
     handleVerififedCodeChange = (event) => {
-        this.setState({ verfiedCode: event.target.value })
-    }
-    
+        this.setState({ verfiedCode: event.target.value });
+    };
+
     handleUsernameChange = (event) => {
         this.setState({ username: event.target.value });
-      };
-
+    };
 
     handlePasswordChange = (event) => {
         this.setState({ password: event.target.value });
     };
-    
+
     signIn() {
-        const username = this.state.username
-        const password = this.state.password
+        const username = this.state.username;
+        const password = this.state.password;
         return Auth.signIn({
             username: username,
-            password: password
+            password: password,
         })
-        .then(async () => {
-            await Auth.currentSession()
-            .then(res=>{
-                let jwt = res.getAccessToken().getJwtToken()
-                localStorage.setItem("idToken", res.idToken.jwtToken);
-                localStorage.setItem("accessToken", jwt);
-                let userProfile = jwtDecode(localStorage.getItem("idToken"));
-                localStorage.setItem("userProfile", JSON.stringify(userProfile));
-              })
-        })
-        .catch((err) => {
-            console.log(err)
-            if (err.code === "UserNotConfirmedException"){
-                this.setState({
-                    verified: false, 
-                    barDisplay: 'None',
-                    buttonDisplay: ''
-                })
-                return null;
-            }
-            this.setState({
-                errorMessage: err.message, 
-                barDisplay: 'None', 
-                buttonDisplay: '', 
+            .then(async () => {
+                await Auth.currentSession().then((res) => {
+                    let jwt = res.getAccessToken().getJwtToken();
+                    localStorage.setItem("idToken", res.getIdToken().getJwtToken());
+                    localStorage.setItem("accessToken", jwt);
+
+                    let userProfile = jwtDecode(localStorage.getItem("idToken"));
+                    localStorage.setItem("userProfile", JSON.stringify(userProfile));
+
+                    let userGroups = res.getIdToken().payload["cognito:groups"];
+                    if (userGroups.includes("ADMIN")) {
+                        this.setState({
+                            isAdmin: true,
+                        });
+                    } else if (userGroups.includes("MENTOR")) {
+                        this.setState({
+                            isSeniorExec: true,
+                        });
+                    }
+                });
             })
-            return null;
-        })
+            .catch((err) => {
+                console.log(err);
+                if (err.code === "UserNotConfirmedException") {
+                    this.setState({
+                        verified: false,
+                        barDisplay: "None",
+                        buttonDisplay: "",
+                    });
+                    return null;
+                }
+                this.setState({
+                    errorMessage: err.message,
+                    barDisplay: "None",
+                    buttonDisplay: "",
+                });
+                return null;
+            });
     }
-    
+
     resendCode = async (event) => {
         await Auth.resendSignUp(this.state.username).then(() => {
             this.setState({
-                codeMessage: 'Code has been emailed to you. Click here to resend code'
-            })
-        })
-    }
-    
+                codeMessage: "Code has been emailed to you. Click here to resend code",
+            });
+        });
+    };
+
     handleVerify = async (event) => {
         this.setState({
-            errorMessage: '', 
-            codeMessage: 'Resend Code'
-        })
-        await Auth.confirmSignUp(this.state.username, this.state.verfiedCode)
-        .then(() => {
-            this.setState({signedIn: true})
-                // TODO: Get information from AWS cognito pool
-                // TODO: Check what role the user is, will redirect to different dashboard
-                let isSeniorExec = false; // will set this based on role
-                this.props.appContext.setState({
-                    currentScreen: (
-                        <Dashboard
-                            appContext={this.props.appContext}
-                            isSeniorExec={isSeniorExec}
-                        />
-                    ),
-                });
-        }).catch(err => {
-            console.log(err)
-            this.setState({
-                errorMessage: "Wrong Code"
-            })
-            return;
-        })
-    }
-    
-    handleClick2=()=>{
-        this.props.appContext.setState({
-            currentScreen: (
-                <AdminDashboard
-                    appContext={this.props.appContext}
-                    
-                />
-            ),
+            errorMessage: "",
+            codeMessage: "Resend Code",
         });
-    }
+        await Auth.confirmSignUp(this.state.username, this.state.verfiedCode)
+            .then(() => {
+                this.setState({ signedIn: true });
+                if (this.state.isAdmin === true) {
+                    this.props.appContext.setState({
+                        currentScreen: (
+                            <AdminDashboard appContext={this.props.appContext} />
+                        ),
+                    });
+                } else {
+                    this.props.appContext.setState({
+                        currentScreen: (
+                            <Dashboard
+                                appContext={this.props.appContext}
+                                isSeniorExec={this.state.isSeniorExec}
+                            />
+                        ),
+                    });
+                }
+            })
+            .catch((err) => {
+                console.log(err);
+                this.setState({
+                    errorMessage: "Wrong Code",
+                });
+                return;
+            });
+    };
 
     handleClick = async (event) => {
         this.setState({
-            errorMessage: ''
-        })
+            errorMessage: "",
+        });
         if (
             this.state.username === "" ||
             this.state.username === undefined ||
@@ -240,43 +247,47 @@ class SignIn extends Component {
             this.state.password === undefined
         ) {
             this.setState({
-                errorMessage: "Not all fields are filled in"
-            })
+                errorMessage: "Not all fields are filled in",
+            });
             return;
         }
-        try{
+        try {
             this.setState({
-                buttonDisplay: 'None', 
-                barDisplay: ''
-            })
-            await this.signIn()
-            .then(val => {
-                if (val === null){
+                buttonDisplay: "None",
+                barDisplay: "",
+            });
+            await this.signIn().then((val) => {
+                if (val === null) {
                     return;
                 }
-                this.setState({signedIn: true})
-                // TODO: Get information from AWS cognito pool
-                // TODO: Check what role the user is, will redirect to different dashboard
-                let isSeniorExec = false; // will set this based on role
-                this.props.appContext.setState({
-                    currentScreen: (
-                        <Dashboard
-                            appContext={this.props.appContext}
-                            isSeniorExec={isSeniorExec}
-                        />
-                    ),
-                });  
-            })
-        }catch(err){
-            window.alert(`Error singing in - ${ err }`)
+                this.setState({ signedIn: true });
+                if (this.state.isAdmin === true) {
+                    this.props.appContext.setState({
+                        currentScreen: (
+                            <AdminDashboard appContext={this.props.appContext} />
+                        ),
+                    });
+                } else {
+                    this.props.appContext.setState({
+                        currentScreen: (
+                            <Dashboard
+                                appContext={this.props.appContext}
+                                isSeniorExec={this.state.isSeniorExec}
+                            />
+                        ),
+                    });
+                }
+            });
+        } catch (err) {
+            window.alert(`Error singing in - ${err}`);
             return;
         }
     };
-    
+
     //"UserNotConfirmedException"
     render() {
         const classes = this.props.classes;
-        if (this.state.verified === false){
+        if (this.state.verified === false) {
             return (
                 <Grid container component="main" className={classes.root}>
                     <CssBaseline />
@@ -293,13 +304,22 @@ class SignIn extends Component {
                         </Toolbar>
                     </AppBar>
                     <Grid item xs={false} sm={4} md={7} className={classes.image} />
-                    <Grid item xs={12} sm={8} md={5} component={Paper} elevation={6} square>
+                    <Grid
+                        item
+                        xs={12}
+                        sm={8}
+                        md={5}
+                        component={Paper}
+                        elevation={6}
+                        square
+                    >
                         <div className={classes.paper}>
                             <img src={MaxBrand} alt="MAX_brand" className={classes.avatar} />
                             <Typography component="h1" variant="body1">
-                                    <b style = {{color: 'Red'}}>{this.state.username}</b> has not been verifed. <br/>
-                                    Please enter the verification code below:
-                            </Typography>
+                                <b style={{ color: "Red" }}>{this.state.username}</b> has not
+                been verifed. <br />
+                Please enter the verification code below:
+              </Typography>
                             <TextField
                                 variant="outlined"
                                 margin="normal"
@@ -311,26 +331,37 @@ class SignIn extends Component {
                                 value={this.state.verfiedCode}
                                 onChange={this.handleVerififedCodeChange}
                             />
-                            <CircularProgress style = {{display: this.state.barDisplay}} className = {classes.circleProgress}/>
+                            <CircularProgress
+                                style={{ display: this.state.barDisplay }}
+                                className={classes.circleProgress}
+                            />
                             <Button
                                 type="submit"
-                                style = {{display: this.state.buttonDisplay}}
+                                style={{ display: this.state.buttonDisplay }}
                                 variant="contained"
                                 className={classes.button}
                                 onClick={this.handleVerify}
                             >
                                 Verify User
-                            </Button>
+              </Button>
                             <br />
                             <Grid container>
                                 <Grid item xs={12}>
-                                    <Typography component="h1" variant="body1" color = {"secondary"}>
+                                    <Typography
+                                        component="h1"
+                                        variant="body1"
+                                        color={"secondary"}
+                                    >
                                         <b> {this.state.errorMessage}</b>
                                     </Typography>
                                 </Grid>
-                                <Grid style = {{display: this.state.buttonDisplay}} item xs={12}>
+                                <Grid
+                                    style={{ display: this.state.buttonDisplay }}
+                                    item
+                                    xs={12}
+                                >
                                     <Link
-                                        style = {{cursor: 'Pointer'}}
+                                        style={{ cursor: "Pointer" }}
                                         variant="body1"
                                         color={"secondary"}
                                         onClick={this.resendCode}
@@ -342,7 +373,7 @@ class SignIn extends Component {
                         </div>
                     </Grid>
                 </Grid>
-            )
+            );
         }
         return (
             <Grid container component="main" className={classes.root}>
@@ -365,7 +396,7 @@ class SignIn extends Component {
                         <img src={MaxBrand} alt="MAX_brand" className={classes.avatar} />
                         <Typography component="h1" variant="h5">
                             Sign in
-                        </Typography>
+            </Typography>
                         <TextField
                             variant="outlined"
                             margin="normal"
@@ -392,35 +423,32 @@ class SignIn extends Component {
                             value={this.state.password}
                             onChange={this.handlePasswordChange}
                         />
-                        <CircularProgress style = {{display: this.state.barDisplay}} className = {classes.circleProgress}/>
+                        <CircularProgress
+                            style={{ display: this.state.barDisplay }}
+                            className={classes.circleProgress}
+                        />
                         <Button
                             type="submit"
-                            style = {{display: this.state.buttonDisplay}}
+                            style={{ display: this.state.buttonDisplay }}
                             variant="contained"
                             className={classes.button}
                             onClick={this.handleClick}
                         >
                             Sign In
-                        </Button>
-                        <Button
-                            className={classes.button}
-                            onClick={this.handleClick2}
-                        >
-                            Admin
-                        </Button>
+            </Button>
                         <br />
                         <Grid container>
                             <Grid item xs={12}>
-                                <Typography component="h1" variant="body1" color = {"secondary"}>
+                                <Typography component="h1" variant="body1" color={"secondary"}>
                                     <b> {this.state.errorMessage}</b>
                                 </Typography>
                             </Grid>
-                            <Grid style = {{display: this.state.buttonDisplay}} item xs={12}>
+                            <Grid style={{ display: this.state.buttonDisplay }} item xs={12}>
                                 <Link href="#" variant="body1">
                                     <b>Forgot your password?</b>
                                 </Link>
                             </Grid>
-                            <Grid style = {{display: this.state.buttonDisplay}} item xs={12}>
+                            <Grid style={{ display: this.state.buttonDisplay }} item xs={12}>
                                 <Link
                                     href="#"
                                     variant="body1"


### PR DESCRIPTION
- Linted the `SignIn.js` file
- Added logic to parse Cognito response payload for user group from a sign-in action
- Added state for tracking if the user is an `Admin` or a `SE`
- Used state to redirect user to `AdminDashboard` or `Dashboard`
- Used state to pass `isSeniorExec` bool as a prop to `Dashboard` 
- Removed Admin sign in button and handler