### PR TITLE
Forgot pwd styling

### DIFF
--- a/src/Components/Registration/FormField.js
+++ b/src/Components/Registration/FormField.js
@@ -1,4 +1,5 @@
 import React, { Component, Fragment } from "react";
+import TextField from "@material-ui/core/TextField";
 import PropTypes from "prop-types";
 
 class FormField extends Component {
@@ -70,7 +71,14 @@ class FormField extends Component {
           </div>
           {/** Render the children nodes passed to component **/}
           {children}
-          <input
+          <TextField
+            variant="outlined"
+            required
+            fullWidth
+            InputLabelProps={{
+              shrink: true,
+            }}
+            label={label}
             type={type}
             className={controlClass}
             id={fieldId}

--- a/src/Components/Registration/PasswordField.js
+++ b/src/Components/Registration/PasswordField.js
@@ -122,7 +122,7 @@ class PasswordField extends Component {
           >
             {children}
             {/** Render the password strength meter **/}
-            <div className={strengthClass}>
+            <div className={strengthClass} style={{ marginBottom: "15px" }}>
               <div
                 className="strength-meter-fill"
                 data-strength={strength}


### PR DESCRIPTION
Fixed styling for Password field in Forgot Password. This also ended up fixing the email and password styling in the registration form! 
![registration-fields](https://user-images.githubusercontent.com/35196626/105169832-2954a080-5b2d-11eb-99db-ccfc15c4d755.png)
![forgot-password](https://user-images.githubusercontent.com/35196626/105169842-2b1e6400-5b2d-11eb-9705-bcf4275fee28.png)
