### PR TITLE
Empty card consistency on filtered pages.

### DIFF
--- a/src/Components/Dashboard/Cards/EmptyCard.js
+++ b/src/Components/Dashboard/Cards/EmptyCard.js
@@ -138,22 +138,28 @@ class EmptyCard extends Component {
       >
         <div className={classes.container}>
           <h1 className={classes.title}>
-            {this.props.type === CardTypes.coffeeChat
+            {this.props.filtered
+              ? ""
+              : this.props.type === CardTypes.coffeeChat
               ? "No booked coffee chats"
               : this.props.type === CardTypes.jobApplication
               ? "No submitted job applications"
               : "No jobs posted"}
           </h1>
           <p className={classes.subtitle}>
-            {this.props.type === CardTypes.coffeeChat
-              ? "To book one, click the Coffee Chats tab above."
-              : this.props.type === CardTypes.jobApplication
-              ? "To view job applications, click the Jobs tab above."
-              : jwtDecode(localStorage.getItem("idToken"))[
-                  "custom:user_type"
-                ] !== "FREE"
-              ? "To post a job, click the button below or post a job from the left nav."
-              : "Free users cannot post jobs. Upgrade to get access to this feature!"}
+            {!this.props.filtered
+              ? this.props.type === CardTypes.coffeeChat
+                ? "To book one, click the Coffee Chats tab above."
+                : this.props.type === CardTypes.jobApplication
+                ? "To view job applications, click the Jobs tab above."
+                : jwtDecode(localStorage.getItem("idToken"))[
+                    "custom:user_type"
+                  ] !== "FREE"
+                ? "To post a job, click the button below or post a job from the left nav."
+                : "Free users cannot post jobs. Upgrade to get access to this feature!"
+              : this.props.type === CardTypes.coffeeChat
+              ? "No coffee chats meet the applied filter"
+              : "No jobs meet the applied filter"}
           </p>
           <span className={classes.button_container}>
             {this.props.type === CardTypes.jobPosting &&

--- a/src/Components/Dashboard/CoffeeChats.js
+++ b/src/Components/Dashboard/CoffeeChats.js
@@ -278,7 +278,7 @@ class CoffeeChats extends Component {
                   alignItems="center"
                   justify="flex-start"
                 >
-                  <EmptyCard type={CardTypes.coffeeChat} />
+                  <EmptyCard type={CardTypes.coffeeChat} filtered={true} />
                 </Grid>
               )
             ) : (

--- a/src/Components/Dashboard/Home.js
+++ b/src/Components/Dashboard/Home.js
@@ -244,7 +244,7 @@ class Home extends Component {
                     alignItems="center"
                     justify="flex-start"
                   >
-                    <EmptyCard type={CardTypes.coffeeChat} />
+                    <EmptyCard type={CardTypes.coffeeChat} filtered={false} />
                   </Grid>
                 )
               ) : (
@@ -313,7 +313,10 @@ class Home extends Component {
                       alignItems="flex-start"
                       justify="flex-start"
                     >
-                      <EmptyCard type={CardTypes.jobApplication} />
+                      <EmptyCard
+                        type={CardTypes.jobApplication}
+                        filtered={false}
+                      />
                     </Grid>
                   )
                 ) : (
@@ -369,7 +372,7 @@ class Home extends Component {
                       alignItems="flex-start"
                       justify="flex-start"
                     >
-                      <EmptyCard type={CardTypes.jobPosting} />
+                      <EmptyCard type={CardTypes.jobPosting} filtered={false} />
                     </Grid>
                   )
                 ) : (
@@ -433,7 +436,10 @@ class Home extends Component {
                       alignItems="flex-start"
                       justify="flex-start"
                     >
-                      <EmptyCard type={CardTypes.jobApplication} />
+                      <EmptyCard
+                        type={CardTypes.jobApplication}
+                        filtered={false}
+                      />
                     </Grid>
                   )
                 ) : (
@@ -488,7 +494,7 @@ class Home extends Component {
                       alignItems="flex-start"
                       justify="flex-start"
                     >
-                      <EmptyCard type={CardTypes.jobPosting} />
+                      <EmptyCard type={CardTypes.jobPosting} filtered={false} />
                     </Grid>
                   )
                 ) : (

--- a/src/Components/Dashboard/Jobs.js
+++ b/src/Components/Dashboard/Jobs.js
@@ -369,7 +369,7 @@ class JobBoard extends Component {
                   alignItems="flex-start"
                   justify="flex-start"
                 >
-                  <EmptyCard type={CardTypes.jobApplication} />
+                  <EmptyCard type={CardTypes.jobApplication} filtered={true} />
                 </Grid>
               )
             ) : (

--- a/src/Components/Dashboard/Submissions.js
+++ b/src/Components/Dashboard/Submissions.js
@@ -387,7 +387,7 @@ class JobBoard extends Component {
                   alignItems="center"
                   justify="center"
                 >
-                  <EmptyCard type={CardTypes.jobApplication} />
+                  <EmptyCard type={CardTypes.jobApplication} filtered={true} />
                 </Grid>
               )
             ) : (


### PR DESCRIPTION
Noticed that the empty card on pages post-filter didn't make sense. Updated to make more sense.

Before change; jobs empty card after filter:
![image](https://user-images.githubusercontent.com/13268990/106399328-f2607380-63e5-11eb-8fc1-2bac3474a2e8.png)

Before change; chats empty card after filter:
![image](https://user-images.githubusercontent.com/13268990/106399333-01dfbc80-63e6-11eb-8e34-39d5458a3c98.png)

After change; jobs empty card after filter:
![image](https://user-images.githubusercontent.com/13268990/106399307-d5c43b80-63e5-11eb-84f6-845ed00839b8.png)

After change; chats empty card after filter:
![image](https://user-images.githubusercontent.com/13268990/106399312-dfe63a00-63e5-11eb-9b86-539dfa7e8b59.png)
